### PR TITLE
acpi: flesh out and rework compared to the illustrative doc

### DIFF
--- a/about.adoc
+++ b/about.adoc
@@ -17,5 +17,6 @@
 | Profile         | RISC-V Profile cite:[Profile].
 | SBI             | RISC-V Supervisor Binary Interface Specification cite:[SBI].
 | SMBIOS          | System Management BIOS cite:[SMBIOS].
+| TAD             | Time and Alarm Device cite:[ACPI] Section 9.17.
 | UEFI            | Unified Extensible Firmware Interface Specification cite:[UEFI].
 |===

--- a/about.adoc
+++ b/about.adoc
@@ -17,6 +17,7 @@
 | Profile         | RISC-V Profile cite:[Profile].
 | SBI             | RISC-V Supervisor Binary Interface Specification cite:[SBI].
 | SMBIOS          | System Management BIOS cite:[SMBIOS].
+| System          | A system is the entirety of a computing entity, including all elements in a platform (hardware, firmware) and software (hypervisor, operating system, user applications, user data). A system can be thought of both as a logical construct (e.g. a software stack) or physical construct (e.g. a notebook, a desktop, a server, a network switch, etc).
 | TAD             | Time and Alarm Device cite:[ACPI] Section 9.17.
 | UEFI            | Unified Extensible Firmware Interface Specification cite:[UEFI].
 |===

--- a/about.adoc
+++ b/about.adoc
@@ -13,6 +13,7 @@
 | DT              | DeviceTree cite:[DT].
 | EBBR            | Embedded Base Boot Requirements Specification cite:[EBBR].
 | OSV             | Operating System Vendor.
+| OS              | Operating System or Hypervisor.
 | Profile         | RISC-V Profile cite:[Profile].
 | SBI             | RISC-V Supervisor Binary Interface Specification cite:[SBI].
 | SMBIOS          | System Management BIOS cite:[SMBIOS].

--- a/acpi.adoc
+++ b/acpi.adoc
@@ -7,7 +7,7 @@ This section defines mandatory and optional ACPI requirements on top of the ACPI
 
 === ACPI High-Level Requirements
 
-A compliant platform must:
+A compliant system must:
 
 * Conform to UEFI specification requirements for ACPI:
 ** RISC-V Platforms (cite:[UEFI] Section 2.3.7)
@@ -28,7 +28,7 @@ ACPI support.
 
 ==== HW-Reduced ACPI Model
 
-Compliant RISC-V platforms only implement the HW-Reduced ACPI Model. This means the hardware portion of
+Compliant RISC-V systems only implement the HW-Reduced ACPI Model. This means the hardware portion of
 cite:[ACPI] (Section 4) is not required or supported. All functionality is instead provided through equivalent
 software-defined interfaces and the complexity in supporting ACPI is reduced.
 
@@ -44,7 +44,7 @@ The following additional BRS requirements apply:
 
 ==== Hart Performance Control
 
-If the platform provides support for OS-directed hart performance control, then it must be exposed using
+If the system provides support for OS-directed hart performance control, then it must be exposed using
 Collaborative Processor Performance Control (CPPC, cite:[ACPI] Section 8).
 
 ==== Time and Alarm Device
@@ -64,7 +64,7 @@ through the driver-backed OperationRegion.
 
 This section lists additional BRS-specific requirements
 for the mandatory and conditionally-required ACPI tables in a compliant
-platform.
+system.
 
 This section does not list ACPI tables without additional BRS-imposed
 requirements.
@@ -77,7 +77,7 @@ syntax and semantics of the ACPI or other relevant firmware specification.
 Entry ordering can be correlated with initialization order by an OS, but
 should not be taken to reflect affinity in resource sharing,
 e.g. sockets, caches, etc. RINTC hart ID and ACPI Processor UID should
-not be decoded in a platform-specific manner to divine CPU topology.
+not be decoded in a system-specific manner to divine CPU topology.
 The PPTT Processor Properties Topology Table (PPTT) is to be used to
 describe affinities.
 
@@ -85,13 +85,13 @@ describe affinities.
 
 The Processor Properties Table (PPTT, cite:[ACPI] Section 5.2.29)
 describes the hart affinities and shared resources, such as caches.
-It is mandatory, even for platforms with a simple hart topology.
+It is mandatory, even for systems with a simple hart topology.
 
 ==== Conditionally Required ACPI Tables
 
 This section lists BRS-specific requirements for ACPI tables that depend
-on hardware features that may not be present in compliant platforms.
-For example, some platforms may not have PCIe busses or a serial port.
+on hardware features that may not be present in compliant systems.
+For example, some systems may not have PCIe busses or a serial port.
 
 ===== MCFG
 

--- a/acpi.adoc
+++ b/acpi.adoc
@@ -28,12 +28,14 @@ ACPI support.
 
 ==== HW-Reduced ACPI Model
 
-Compliant RISC-V systems only implement the HW-Reduced ACPI Model. This means the hardware portion of
-cite:[ACPI] (Section 4) is not required or supported. All functionality is instead provided through equivalent
+Compliant RISC-V systems only implement the HW-Reduced ACPI Model cite:[ACPI] (Section 4.1).
+This means the hardware portion of cite:[ACPI] (Section 4) is not required or
+supported. All functionality is instead provided through equivalent
 software-defined interfaces and the complexity in supporting ACPI is reduced.
 
 The following additional BRS requirements apply:
 
+* No FACS table.
 * Both interrupt-signaled and GPIO-signaled ACPI Events are supported
   (cite:[ACPI] Section 5.6)
 * There is at least 1 wake event.

--- a/acpi.adoc
+++ b/acpi.adoc
@@ -1,26 +1,142 @@
 [[acpi]]
 == ACPI Requirements
-=== ACPI Version
-=== ACPI-provided Data Structures
-=== ACPI Tables
-==== Mandatory ACPI Tables
-===== RSDP
-===== XSDT
-===== FADT
-===== DSDT and SSDT
-===== MADT
-===== RHCT
-===== SPCR
-===== MCFG
-===== PPTT
-==== Recommended ACPI Tables
-==== Optional ACPI Tables
-=== ACPI Definition Blocks
-=== ACPI Methods and Objects
-==== Global Methods and Objects
-==== Device Methods and Objects
-==== Event Signaling
-==== Address Translation Support
-=== Hardware Requirements Imposed by ACPI
-==== Processor Performance Control
+
+The Advanced Configuration and Power Interface specification provides the OS-centric view of system configuration, various hardware resources, events and power management.
+
+This section defines mandatory and optional ACPI requirements on top of the ACPI specification cite:[ACPI]. Additional non-normative guidance may be found in <<ACPI Implementation Guidance>>.
+
+=== ACPI High-Level Requirements
+
+A compliant platform must:
+
+* Conform to UEFI specification requirements for ACPI:
+** RISC-V Platforms (cite:[UEFI] Section 2.3.7)
+** Industry Standard Configuration Tables (cite:[UEFI] Section 4.6.1.1)
+* Conform to version 6.6 of the ACPI specification, including RISC-V requirements listed in:
+** Multiple APIC Description Table (MADT, cite:[ACPI] Section 5.2.12)
+** RISC-V Hart Capabilities Table (RHCT, cite:[ACPI] Section 5.2.36)
+* Meet the requirements in <<Minimum Hardware Requirements Imposed By ACPI>>
+* Be 64-bits clean.
+** RSDT must not be implemented.
+** 32-bit address fields must be 0.
+* Implement a firmware-first APEI model (cite:[ACPI] Section 18.4)
+
+=== ACPI-specific Hardware Requirements
+
+This section lists the BRS-specific hardware requirements imposed by
+ACPI support.
+
+==== HW-Reduced ACPI Model
+
+Compliant RISC-V platforms only implement the HW-Reduced ACPI Model. This means the hardware portion of
+cite:[ACPI] (Section 4) is not required or supported. All functionality is instead provided through equivalent
+software-defined interfaces and the complexity in supporting ACPI is reduced.
+
+The following additional BRS requirements apply:
+
+* Both interrupt-signaled and GPIO-signaled ACPI Events are supported
+  (cite:[ACPI] Section 5.6)
+* There is at least 1 wake event.
+** Note: for systems that do not support Sx states except S5 soft off, this can be just the power button.
+* For the ACPI Platform Error Interfaces (APEI) support:
+** There is 1 event for non-fatal error signaling (cite:[ACPI] Section 18.3.2.7.2)
+** There is 1 NMI-equivalent signal for use in fatal errors (cite:[ACPI] Section 18)
+
+==== Hart Performance Control
+
+If the platform provides support for OS-directed hart performance control, then it must be exposed using
+Collaborative Processor Performance Control (CPPC, cite:[ACPI] Section 8).
+
 ==== Time and Alarm Device
+
+UEFI Runtime Service should be used to provide time services to the
+OS, unless the RTC is subject to arbitration issues between concurrent
+OS and UEFI accesses to the underlying hardware. See <<<UEFI Real-Time
+Clock>>>.
+
+In situations where the TAD device depends on a vendor-specific OS
+driver for correct function (SPI, I2C, etc), the TAD must be
+function if the OS driver is not loaded. E.g. when a dependent
+driver is loaded, an AML method switches further accesses to go
+through the driver-backed OperationRegion.
+
+=== Additional ACPI Table Requirements
+
+This section lists additional BRS-specific requirements
+for the mandatory and conditionally-required ACPI tables in a compliant
+platform.
+
+This section does not list ACPI tables without additional BRS-imposed
+requirements.
+
+All ACPI tables not listed here may be used, if they comply with the
+syntax and semantics of the ACPI or other relevant firmware specification.
+
+==== MADT
+
+Entry ordering can be correlate with initialization order by an OS, but
+should not be taken to reflect affinity in resource sharing,
+e.g. sockets, caches, etc. RINTC hart ID and ACPI Processor UID should
+not be decoded in a platform-specific manner to divine CPU topology.
+The PPTT Processor Properties Topology Table (PPTT) is to be used to
+describe affinities.
+
+==== PPTT
+
+The Processor Properties Table (PPTT, cite:[ACPI] Section 5.2.29)
+describes the hart affinities and shared resources, such as caches.
+It is mandatory, even for platforms with a simple hart topology.
+
+==== Conditionally Required ACPI Tables
+
+This section lists BRS-specific requirements for ACPI tables that depend
+on hardware features that may not be present in compliant platforms.
+For example, some platforms may not have PCIe busses or a serial port.
+
+===== MCFG
+
+The PCI Memory-mapped Configuration Space (MCFG) table cite:[PCIFW] is
+required if PCIe is made available to the OS.
+
+* PCIe configuration space must be exposed to the OS in an ECAM-compatible manner.
+* MCFG table must not require a custom vendor-specific PCIe root complex OS driver.
+
+===== SPCR
+
+The Serial Port Console Redirection Table cite:[SPCR] is required on
+systems where the graphics hardware is not present or not made
+available to an OS loader via the standard UEFI
+EFI_GRAPHICS_OUTPUT_PROTOCOL interface. In these cases, the table
+provides essential configuration for an early OS boot console.
+
+Additional requirements:
+
+* Revision 2 or later of SPCR.
+* Populate Interrupt Type and Global System Interrupt fields with
+non-zero values unless the interface is polled-mode only.
+* For NS16550-compatible UARTs:
+** Use Interface Type 0x12 (16550-compatible with parameters defined in
+Generic Address Structure).
+** There must be a matching AML device object.
+
+=== ACPI Methods and Objects
+
+This section lists additional BRS-specific requirements for ACPI
+methods and objects.
+
+==== Global Methods and Objects
+
+Harts must be defined under \_SB (System Bus) namespace and not in the deprecated \_PR (Processors) namespace.
+
+==== Device Methods and Objects
+
+* _CCA: Cache Coherency Attribute. This object provides information
+  about whether a device has to manage cache coherency and about
+  hardware support. This object is mandatory for all devices that
+  can access CPU-visible memory. (cite:[ACPI] Section 6.2.17)
+* _PRS: Possible Resource Settings. Not supported.
+* _SRS: Set Resource Settings. Not supported.
+* _CRS: Current Resource Settings
+** PCIe Root Complex descriptors must not contain resources of type DWordIO, QWordIO or ExtendedIO as the legacy PCI I/O port space is not supported.
+
+

--- a/acpi.adoc
+++ b/acpi.adoc
@@ -44,8 +44,9 @@ The following additional BRS requirements apply:
 
 ==== Hart Performance Control
 
-If the system provides support for OS-directed hart performance control, then it must be exposed using
-Collaborative Processor Performance Control (CPPC, cite:[ACPI] Section 8).
+If the platform provides support for OS-directed hart performance control and power management,
+then it must be exposed using Collaborative Processor Performance Control (CPPC, cite:[ACPI] Section 8.4.6).
+Processor idle states must be described using Low Power Idle (LPI, cite:[ACPI] Section 8.4.3).
 
 ==== Time and Alarm Device
 

--- a/acpi.adoc
+++ b/acpi.adoc
@@ -54,9 +54,9 @@ OS, unless the RTC is subject to arbitration issues between concurrent
 OS and UEFI accesses to the underlying hardware. See <<<UEFI Real-Time
 Clock>>>.
 
-In situations where the TAD device depends on a vendor-specific OS
-driver for correct function (SPI, I2C, etc), the TAD must be
-function if the OS driver is not loaded. E.g. when a dependent
+In situations where the Time and Alarm Device (TAD) depends on a
+vendor-specific OS driver for correct function (SPI, I2C, etc), the TAD must
+be functional if the OS driver is not loaded. That is, when a dependent
 driver is loaded, an AML method switches further accesses to go
 through the driver-backed OperationRegion.
 
@@ -74,7 +74,7 @@ syntax and semantics of the ACPI or other relevant firmware specification.
 
 ==== MADT
 
-Entry ordering can be correlate with initialization order by an OS, but
+Entry ordering can be correlated with initialization order by an OS, but
 should not be taken to reflect affinity in resource sharing,
 e.g. sockets, caches, etc. RINTC hart ID and ACPI Processor UID should
 not be decoded in a platform-specific manner to divine CPU topology.
@@ -111,9 +111,8 @@ provides essential configuration for an early OS boot console.
 
 Additional requirements:
 
-* Revision 2 or later of SPCR.
-* Populate Interrupt Type and Global System Interrupt fields with
-non-zero values unless the interface is polled-mode only.
+// Version 4 is WIP https://github.com/andreiw/ms-acpi-tables-for-riscv/tree/riscv_plus_improvements
+* Revision 4 or later of SPCR.
 * For NS16550-compatible UARTs:
 ** Use Interface Type 0x12 (16550-compatible with parameters defined in
 Generic Address Structure).

--- a/appendices.adoc
+++ b/appendices.adoc
@@ -32,4 +32,18 @@
 ===== ACPI Device Object for CXL Root Device
 ==== NUMA
 === Firmware Implementation Guidance
+
+The guidance section is non-normative, and covers certain
+implementation choices, suggestions, historical context, etc.
+
 ==== ACPI Implementation Guidance
+
+Certain implementations may make use of the RISC-V Functional Fixed hardware Specification cite:[FFH].
+
+===== FADT
+
+cite:[ACPI] (Section 5.2.9) provides guidance on filling the
+Fixed ACPI Description Table for HW-reduced ACPI.
+
+Don't forget to select an appropriate Preferred PM Profile.
+

--- a/appendices.adoc
+++ b/appendices.adoc
@@ -26,32 +26,10 @@
 ===== CXL Protocols
 ===== PCIe Protocols
 ===== Graphics Protocols
-=== Recommended and Conditionally Required ACPI Tables
-==== I/O Topology
-==== TPM
-==== Platform Error Interfaces
-==== NUMA
-==== PCC
-==== Platform Debug Trigger
-==== NVDIMM
-==== Graphics Resource Table
-==== IPMI
-==== CXL
-==== iSCSI and NVMe-oF
-==== DBG2
-=== Recommended and Conditionally Required ACPI Methods
-==== CPU Performance Control
-==== CPU and System Idle Control
-==== NUMA
-==== IPMI
-==== Device Configuration and Control
-==== Resources
-==== CXL
-==== Time and Alarm
-==== PCI and PCIe
 === CXL Requirements
 ==== CXL Host Bridge
 ==== CXL Root Device
 ===== ACPI Device Object for CXL Root Device
 ==== NUMA
-
+=== Firmware Implementation Guidance
+==== ACPI Implementation Guidance

--- a/brs.bib
+++ b/brs.bib
@@ -38,3 +38,7 @@
   title = {RISC-V Profile},
   url = {https://github.com/riscv/riscv-profiles}
 }
+@electronic{FFH,
+  title = {RISC-V Functional Fixed Hardware Specification},
+  url = {https://github.com/riscv-non-isa/riscv-acpi-ffh}
+}

--- a/brs.bib
+++ b/brs.bib
@@ -3,11 +3,11 @@
   url = {https://arm-software.github.io/ebbr/}
 }
 @electronic{ACPI,
-  title = {Advanced Configuration and Power Interface Specification},
+  title = {Advanced Configuration and Power Interface Specification 6.6},
   url = {https://uefi.org/specifications}
 }
 @electronic{UEFI,
-  title = {Unified Extensible Firmware Interface Specification},
+  title = {Unified Extensible Firmware Interface Specification 2.11},
   url = {https://uefi.org/specifications}
 }
 @electronic{SMBIOS,
@@ -21,6 +21,14 @@
 @electronic{SBI,
   title = {RISC-V Supervisor Binary Interface Specification},
   url = {https://github.com/riscv-non-isa/riscv-sbi-doc}
+}
+@electronic{SPCR,
+  title = {Serial Port Console Redirection Table (SPCR)},
+  url = {https://learn.microsoft.com/en-us/windows-hardware/drivers/serports/serial-port-console-redirection-table}
+}
+@electronic{PCIFW,
+  title = {PCI Firmware Specification Revision 3.3},
+  url = {https://members.pcisig.com/wg/PCI-SIG/document/folder/862}
 }
 @electronic{PRIV,
   title = {RISC-V Instruction Set Manual, Volume II: Privileged Architecture},

--- a/contributors.adoc
+++ b/contributors.adoc
@@ -1,8 +1,14 @@
 == Contributors
 
-This RISC-V specification has been contributed to directly or indirectly by:
+This RISC-V specification has been contributed to directly or indirectly by (in alphabetical order):
 
 [%hardbreaks]
 * Aaron Durbin <adurbin@rivosinc.com>
+* Andrew Jones <ajones@ventanamicro.com>
+* Jared McNeill <jmcneill@vmware.com>
+* Heinrich Schuchardt <heinrich.schuchardt@canonical.com>
+* Sunil V L <sunilvl@ventanamicro.com>
+* Paul Walmsley <paul.walmsley@sifive.com>
 * Andrei Evgenievich Warkentin <andrei.warkentin@intel.com>
 
+We express our gratitude to everyone that contributed to, reviewed, or improved the document through their comments and questions.

--- a/header.adoc
+++ b/header.adoc
@@ -44,7 +44,7 @@ Aaron Durbin; Andrei Warkentin; OS-A SEE Task Group
 .This document is in the link:http://riscv.org/spec-state[Development state]
 ====
 Assume everything can change. This draft specification will change before 
-being accepted as standard, so implementations made to this draft 
+being accepted as standard, so systems made to this draft 
 specification will likely not conform to the future standard.
 ====
 

--- a/smbios.adoc
+++ b/smbios.adoc
@@ -10,32 +10,32 @@
 ==== Type 04: Processor Information (Required)
 ==== Type 07: Cache Information (Required)
 ==== Type 08: Port Connector Information (Recommended)
-Recommended for platforms with physical ports.
+Recommended for systems with physical ports.
 
 ==== Type 09: System Slots (Conditionally Required)
-Required for platforms with expansion slots.
+Required for systems with expansion slots.
 
 ==== Type 11: OEM Strings (Recommended)
 ==== Type 13: BIOS Language Information (Recommended)
 ==== Type 14: Group Associations (Recommended)
-Recommended for platforms to describe associations between SMBIOS types.
+Recommended for systems to describe associations between SMBIOS types.
 
 ==== Type 16: Physical Memory Array (Required)
 ==== Type 17: Memory Device (Required)
 ==== Type 19: Memory Array Mapped Address (Required)
 ==== Type 32: System Boot Information (Required)
 ==== Type 38: IPMI Device Information (Conditionally Required)
-Required for platforms with an IPMIv1.0 BMC Host Interface.
+Required for systems with an IPMIv1.0 BMC Host Interface.
 
 ==== Type 39: System Power Supplies (Recommended)
 Recommended for servers.
 
 ==== Type 41: Onboard Devices Extended Information (Recommended)
 ==== Type 42: Redfish Host Interface (Conditionally Required)
-Required for platforms supporting the Redfish Host Interface.
+Required for systems supporting the Redfish Host Interface.
 
 ==== Type 43: TPM Device (Conditionally Required)
-Required for platforms with a TPM.
+Required for systems with a TPM.
 
 ==== Type 44: Standard Processor Additional Information (Required)
 ==== Type 45: Firmware Inventory Information (Recommended)


### PR DESCRIPTION
The spec aims to provide only the additional BRS requirements on top of existing specification and industry norms.