### PR TITLE
acpi: flesh out non-normative portion

### DIFF
--- a/about.adoc
+++ b/about.adoc
@@ -17,6 +17,7 @@
 | Profile         | RISC-V Profile cite:[Profile].
 | SBI             | RISC-V Supervisor Binary Interface Specification cite:[SBI].
 | SMBIOS          | System Management BIOS cite:[SMBIOS].
+| SoC             | System on a chip, a combination of processor and supporting chipset logic in single package.
 | System          | A system is the entirety of a computing entity, including all elements in a platform (hardware, firmware) and software (hypervisor, operating system, user applications, user data). A system can be thought of both as a logical construct (e.g. a software stack) or physical construct (e.g. a notebook, a desktop, a server, a network switch, etc).
 | TAD             | Time and Alarm Device cite:[ACPI] Section 9.17.
 | UEFI            | Unified Extensible Firmware Interface Specification cite:[UEFI].

--- a/acpi.adoc
+++ b/acpi.adoc
@@ -87,6 +87,8 @@ not be decoded in a system-specific manner to divine CPU topology.
 The PPTT Processor Properties Topology Table (PPTT) is to be used to
 describe affinities.
 
+<<acpi-guidance-madt, See additional guidance>>.
+
 ==== PPTT
 
 The Processor Properties Table (PPTT, cite:[ACPI] Section 5.2.29)
@@ -102,10 +104,16 @@ For example, some systems may not have PCIe busses or a serial port.
 [[acpi-mcfg]]
 ===== MCFG
 
-The PCI Memory-mapped Configuration Space (MCFG) table cite:[PCIFW] must only be present if and only if cite:[PCIFW] compatible PCIe is made available to the OS.
+The PCI Memory-mapped Configuration Space (MCFG) table cite:[PCIFW] must only be present
+if and only if cite:[PCIFW] compatible non-hot-removable PCIe segments are made available
+to the OS.
 
 * PCIe configuration space must be exposed to the OS in an ECAM-compatible manner.
 * MCFG table must not require a custom vendor-specific PCIe root complex OS driver.
+
+Please see PCI Services in ACPI (cite:[ACPI], Section 4) for more ACPI requirements relating to PCIe support.
+
+<<acpi-guidance-pcie, See additional guidance>>.
 
 [[acpi-spcr]]
 ===== SPCR
@@ -125,11 +133,15 @@ Additional requirements:
 Generic Address Structure).
 ** There must be a matching AML device object.
 
+<<acpi-guidance-spcr, See additional guidance>>.
+
 [[acpi-aml]]
 === ACPI Methods and Objects
 
 This section lists additional BRS-specific requirements for ACPI
 methods and objects.
+
+<<acpi-guidance-aml, See additional guidance>>.
 
 ==== Global Methods and Objects
 
@@ -143,6 +155,9 @@ Harts must be defined under \_SB (System Bus) namespace and not in the deprecate
   can access CPU-visible memory. (cite:[ACPI] Section 6.2.17)
 * _PRS: Possible Resource Settings. Not supported.
 * _SRS: Set Resource Settings. Not supported.
+
+===== PCIe Root Complex Devices
+
 * _CRS: Current Resource Settings
 ** PCIe Root Complex descriptors must not contain resources of type DWordIO, QWordIO or ExtendedIO as the legacy PCI I/O port space is not supported.
 

--- a/acpi.adoc
+++ b/acpi.adoc
@@ -17,8 +17,9 @@ A compliant system must:
 ** RISC-V Hart Capabilities Table (RHCT, cite:[ACPI] Section 5.2.36)
 * Meet the requirements in <<Minimum Hardware Requirements Imposed By ACPI>>
 * [[acpi-64bit-clean]]Be 64-bits clean.
-** RSDT must not be implemented, with RsdtAddress in RSDP be 0.
+** RSDT must not be implemented, with RsdtAddress in RSDP set to 0.
 ** 32-bit address fields must be 0.
+** <<acpi-guidance-64bit-clean, See additional guidance>>.
 * Implement a firmware-first APEI model (cite:[ACPI] Section 18.4)
 
 === ACPI-specific Hardware Requirements

--- a/acpi.adoc
+++ b/acpi.adoc
@@ -3,7 +3,7 @@
 
 The Advanced Configuration and Power Interface specification provides the OS-centric view of system configuration, various hardware resources, events and power management.
 
-This section defines mandatory and optional ACPI requirements on top of the ACPI specification cite:[ACPI]. Additional non-normative guidance may be found in <<ACPI Implementation Guidance>>.
+This section defines mandatory and optional ACPI requirements on top of the ACPI specification cite:[ACPI]. Additional non-normative guidance may be found in the <<acpi-guidance, appendix>>.
 
 === ACPI High-Level Requirements
 
@@ -16,8 +16,8 @@ A compliant system must:
 ** Multiple APIC Description Table (MADT, cite:[ACPI] Section 5.2.12)
 ** RISC-V Hart Capabilities Table (RHCT, cite:[ACPI] Section 5.2.36)
 * Meet the requirements in <<Minimum Hardware Requirements Imposed By ACPI>>
-* Be 64-bits clean.
-** RSDT must not be implemented.
+* [[acpi-64bit-clean]]Be 64-bits clean.
+** RSDT must not be implemented, with RsdtAddress in RSDP be 0.
 ** 32-bit address fields must be 0.
 * Implement a firmware-first APEI model (cite:[ACPI] Section 18.4)
 
@@ -26,6 +26,7 @@ A compliant system must:
 This section lists the BRS-specific hardware requirements imposed by
 ACPI support.
 
+[[acpi-hw-reduced]]
 ==== HW-Reduced ACPI Model
 
 Compliant RISC-V systems only implement the HW-Reduced ACPI Model cite:[ACPI] (Section 4.1).
@@ -75,6 +76,7 @@ requirements.
 All ACPI tables not listed here may be used, if they comply with the
 syntax and semantics of the ACPI or other relevant firmware specification.
 
+[[acpi-madt]]
 ==== MADT
 
 Entry ordering can be correlated with initialization order by an OS, but
@@ -96,14 +98,15 @@ This section lists BRS-specific requirements for ACPI tables that depend
 on hardware features that may not be present in compliant systems.
 For example, some systems may not have PCIe busses or a serial port.
 
+[[acpi-mcfg]]
 ===== MCFG
 
-The PCI Memory-mapped Configuration Space (MCFG) table cite:[PCIFW] is
-required if PCIe is made available to the OS.
+The PCI Memory-mapped Configuration Space (MCFG) table cite:[PCIFW] must only be present if and only if cite:[PCIFW] compatible PCIe is made available to the OS.
 
 * PCIe configuration space must be exposed to the OS in an ECAM-compatible manner.
 * MCFG table must not require a custom vendor-specific PCIe root complex OS driver.
 
+[[acpi-spcr]]
 ===== SPCR
 
 The Serial Port Console Redirection Table cite:[SPCR] is required on
@@ -121,6 +124,7 @@ Additional requirements:
 Generic Address Structure).
 ** There must be a matching AML device object.
 
+[[acpi-aml]]
 === ACPI Methods and Objects
 
 This section lists additional BRS-specific requirements for ACPI

--- a/appendices.adoc
+++ b/appendices.adoc
@@ -36,14 +36,8 @@
 The guidance section is non-normative, and covers certain
 implementation choices, suggestions, historical context, etc.
 
+[[acpi-guidance]]
 ==== ACPI Implementation Guidance
+include::non-normative/acpi.adoc[]
 
-Certain implementations may make use of the RISC-V Functional Fixed hardware Specification cite:[FFH].
-
-===== FADT
-
-cite:[ACPI] (Section 5.2.9) provides guidance on filling the
-Fixed ACPI Description Table for HW-reduced ACPI.
-
-Don't forget to select an appropriate Preferred PM Profile.
 

--- a/non-normative/acpi.adoc
+++ b/non-normative/acpi.adoc
@@ -1,0 +1,103 @@
+ACPI information is structured as tables with the address of the root of these
+tables known as Root System Description Table (RSDP) passed to the OS
+via a EFI_ACPI_20_TABLE_GUID configuration table in the UEFI firmware.
+The Operating System uses this address to locate all other ACPI tables.
+
+Certain implementations may make use of the RISC-V Functional Fixed hardware Specification cite:[FFH].
+
+<<acpi-guidance-tab-min>> defines a minimum set of structures that must exist to support basic booting of RISC-V system with ACPI support. <<acpi-guidance-tab-opt>> lists additional possibile ACPI tables based on the optional features that can be supported. The latter is not meant to be exhaustive and mostly focuses on tables that
+have specific guidance or that expected to be frequently implemented.
+
+.*Minimum required ACPI System Description Tables*
+[[acpi-guidance-tab-min]]
+[cols="3,2,2", width=95%, align="center", options="header"]
+|===
+|ACPI Table                                    |ACPI Section|Note
+|Root System Description Pointer (RSDP)        |5.2.5      | See <<acpi-64bit-clean, high-level requirements>>.
+|Extended System Description Table (XSDT)      |5.2.8      | Contains pointers to other tables.
+|Fixed ACPI Description Table (FADT)           |5.2.9      | See <<acpi-hw-reduced>> and <<acpi-guidance-fadt, the notes below>>.
+|Differentiated System Description Table (DSDT)|5.2.11.1   | See <<acpi-aml>> and <<acpi-guidance-aml, the notes below>>.
+|Multiple APIC Description Table (MADT)        |5.2.12     | See <<acpi-madt>> and <<acpi-guidance-madt, the notes below>>
+|RISC-V Hart Capabilities Table (RHCT)         |New        | Communicates
+information about certain capabilities like ISA string, cache and MMU info.
+|Processor Properties Topology Table (PPTT)    |5.2.29     |CPU and Cache 
+                                                            topology
+                                                            information
+|===
+
+// Add RIMT for IOMMU here.
+
+.*Additional ACPI System Description Tables based on feature support.*
+[[acpi-guidance-tab-opt]]
+[cols="3,2,2", width=95%, align="center", options="header"]
+|===
+|ACPI Table                                    |ACPI Section  |Note
+|Memory-mapped Configuration space (MCFG)      |cite:[PCIFW]  |See <<acpi-guidance-pcie, the notes below>>
+| Secondary System Description Table (SSDT)    |5.2.11.2      |See <<acpi-aml>> and <<acpi-guidance-aml, the notes below>>.
+|Serial Port Console Redirection (SPCR)        |cite:[SPCR]   |See <<acpi-spcr>> and <<acpi-guidance-spcr, the notes below>>
+|System Resource Affinity Table (SRAT)         |5.2.16        |If the platform supports NUMA
+|System Locality Information Table (SLIT)      |5.2.17        |If the platform supports NUMA
+|Boot Error Record Table (BERT)                |18.3.1        |If ACPI RAS is supported
+|Error Injection Table (EINJ)                  |18.6.1        |If ACPI RAS is supported
+|Error Record Serialization Table (ERST)       |18.5          |If ACPI RAS is supported
+|Hardware Error Source Table (HEST)            |18.3.2        |If ACPI RAS is supported
+|===
+
+[[acpi-guidance-aml]]
+===== DSDT and SSDTs
+
+The ACPI name space describes devices which cannot be enumerated by any other standard ways. These typically include SoC embedded memory-mapped I/O devices, such as UARTs, <<acpi-guidance-pcie, PCIe>> or CXL root complexes, GPIO controllers, etc.
+
+It's an implementation choice if the ACPI name space is defined solely with a DSDT or with any additional SSDTs. For example, a UEFI implementation
+may choose to use SSDTs to:
+
+* describe devices that vary across SoC SKUs, revisions or variants.
+* describe devices, where the backing AML is generated or patched at boot time.
+
+// Provide guidance here for converting existing device tree node definitions to ACPI.
+
+// Provide guidance here for describing NS16550-compatible UARTs.
+
+[[acpi-guidance-fadt]]
+===== FADT
+
+cite:[ACPI] (Section 5.2.9) provides guidance on filling the
+Fixed ACPI Description Table for HW-reduced ACPI.
+
+Don't forget to select an appropriate Preferred PM Profile.
+
+[[acpi-guidance-madt]]
+===== MADT
+
+RINTC (per-hart) structures are mandatory. Depending on the interrupt controller implemented by the system, the MADT will also contain either PLIC or IMSIC/APLIC structures.
+
+[[acpi-guidance-pcie]]
+===== PCIe
+
+On some architectures, it became an industry accepted norm to describe PCIe implementations not compliant to the PCI Firmware Specification cite:[PCIFW]
+using specification-defined ACPI tables and objects. RISC-V systems compliant to the BRS must only expose ECAM-compatible implementations using the
+MCFG and the standard AML Hardware ID (HID) PNP0A08 and Compatible ID (CID) PNP0A03, and must not rely on ACPI table header information or other out-of-band
+means of detecting quirked behavior.
+
+Some minor incompatibilities, such as split PCIe configuration spaces or incorrect CFG0 filtering, can be handled by emulating ECAM accesses in privileged firmware
+(e.g. M-mode) or similar facilities (e.g. a hypervisor).
+
+Non-compliant implementations must be exposed using vendor-specific mechanisms (e.g. AML object with custom HID, custom vendor-specific ACPI table if necessary).
+In cases where such PCIe implementations are only used to expose a fixed non-removable device (e.g. USB host controller or NVMe), the device could be exposed via
+a DSDT/SSDT MMIO device object without making the OS aware of the underlying PCIe connection.
+
+// Provide guidance here on AML object used, including interrupt routing, why I/O space is not included.
+
+[[acpi-guidance-spcr]]
+===== SPCR
+
+Early serial console can be implemented using either an NS16550 UART (SPCR Interface Type 0x12) or
+SBI console (SPCR Interface Type 0x15). When SPCR describes SBI console, the OS must use
+the SBI Probe extension (FID #3) to detect the appropriate facilities, e.g. the Debug Console Extension
+(DBCN) or the deprecated legacy console EIDs.
+
+The new Precise Baud Rate field, introduced in cite:[SPCR] rev. 4, allows describing rates faster
+than 115200 baud for NS16550-compatible UARTS.
+
+Hardware not capable of interrupt-driven operation and SBI console should be described with
+Interrupt Type 0 and Global System Interrupt 0.

--- a/non-normative/acpi.adoc
+++ b/non-normative/acpi.adoc
@@ -11,7 +11,6 @@ and disallows the use of 32-bit only structures (thus, RSDP must not be implemen
 as the XSDT is a direct replacement). Thus, the ACPI tables are allowed to be
 located in any part of the physical address space.
 
-
 Certain implementations may make use of the RISC-V Functional Fixed hardware Specification cite:[FFH].
 
 <<acpi-guidance-tab-min>> defines a minimum set of structures that must exist to support basic booting of RISC-V system with ACPI support. <<acpi-guidance-tab-opt>> lists additional possibile ACPI tables based on the optional features that can be supported. The latter is not meant to be exhaustive and mostly focuses on tables that
@@ -67,6 +66,8 @@ may choose to use SSDTs to:
 
 // Provide guidance here for describing NS16550-compatible UARTs.
 
+// Provide guidance here for PCIe RCs, perhaps leverage some of https://www.infradead.org/~mchehab/rst_conversion/PCI/acpi-info.html
+
 [[acpi-guidance-fadt]]
 ===== FADT
 
@@ -88,8 +89,8 @@ using specification-defined ACPI tables and objects. RISC-V systems compliant to
 MCFG and the standard AML Hardware ID (HID) PNP0A08 and Compatible ID (CID) PNP0A03, and must not rely on ACPI table header information or other out-of-band
 means of detecting quirked behavior.
 
-Some minor incompatibilities, such as split PCIe configuration spaces or incorrect CFG0 filtering, can be handled by emulating ECAM accesses in privileged firmware
-(e.g. M-mode) or similar facilities (e.g. a hypervisor).
+Some minor incompatibilities, such as incorrect CFG0 filtering, broken BARs/capabilities for RCs, embedded switches/bridges
+or embedded endpoints can be handled by emulating ECAM accesses in privileged firmware (e.g. M-mode) or similar facilities (e.g. a hypervisor).
 
 Non-compliant implementations must be exposed using vendor-specific mechanisms (e.g. AML object with custom HID, custom vendor-specific ACPI table if necessary).
 In cases where such PCIe implementations are only used to expose a fixed non-removable device (e.g. USB host controller or NVMe), the device could be exposed via

--- a/non-normative/acpi.adoc
+++ b/non-normative/acpi.adoc
@@ -3,6 +3,15 @@ tables known as Root System Description Table (RSDP) passed to the OS
 via a EFI_ACPI_20_TABLE_GUID configuration table in the UEFI firmware.
 The Operating System uses this address to locate all other ACPI tables.
 
+[[acpi-guidance-64bit-clean]] ACPI started as a specification for 32-bit systems,
+so certain tables with physical address pointers (e.g. RSDP, FADT) allow for reporting
+either 32-bit or 64-bit values using different fields. For the sake of simplicity
+and consistency, the BRS disallows the use 32-bit address fields in such structures
+and disallows the use of 32-bit only structures (thus, RSDP must not be implemented,
+as the XSDT is a direct replacement). Thus, the ACPI tables are allowed to be
+located in any part of the physical address space.
+
+
 Certain implementations may make use of the RISC-V Functional Fixed hardware Specification cite:[FFH].
 
 <<acpi-guidance-tab-min>> defines a minimum set of structures that must exist to support basic booting of RISC-V system with ACPI support. <<acpi-guidance-tab-opt>> lists additional possibile ACPI tables based on the optional features that can be supported. The latter is not meant to be exhaustive and mostly focuses on tables that


### PR DESCRIPTION
This should cover the non-server specific portions of https://github.com/riscv-non-isa/riscv-acpi/blob/master/riscv-acpi-guidance.adoc

Still need to cross-check the Illustrative OS-A-SEE Specification if there was anything else interesting there.

Also, APEI/RAS is muddy. Need to understand if there is APEI without RAS.