### PR TITLE
Expand recipes a bit going into further requirements for BRS-I.

### DIFF
--- a/appendices.adoc
+++ b/appendices.adoc
@@ -36,6 +36,10 @@
 The guidance section is non-normative, and covers certain
 implementation choices, suggestions, historical context, etc.
 
+[[recipes-guidance]]
+==== Recipes Guidance
+include::non-normative/recipes.adoc[]
+
 [[acpi-guidance]]
 ==== ACPI Implementation Guidance
 include::non-normative/acpi.adoc[]

--- a/non-normative/recipes.adoc
+++ b/non-normative/recipes.adoc
@@ -1,0 +1,32 @@
+[[recipe-brs-i-guidance]]
+===== BRS-I Recipe Guidance
+
+Systems compliant to BRS-I can successfully boot an existing generic
+operating system image without system-specific customizations, yet
+this might result in an unoptimized experience and non-functioning
+I/O devices until further software updates are activated.
+
+The best analogy would be a typical Intel Architecture motherboard from
+the early 2000s: you could install an OS on it, but the built-in graphics
+might be low-resolution and the sound, built-in network port or power
+management might not work out of the box. You could subsequently load
+the right drivers from the media coming with the board or fetch newest
+ones using a well-supported network adapter.
+
+Heterogeneous performance harts (e.g. mix of "performance" and "efficiency"
+harts) is a great example of a feature outside the current scope of BRS-I,
+yet with potential for adverse effects to a generic operating system
+written against the BRS-I spec. Such a feature does not have a standard
+way of being detected by an OS, leading to scheduling anomalies in
+operating systems that are not specially adapted. Consider two identical
+threads that, unbeknownst to the OS, get scheduled on harts with different
+performance characteristics. This might see dramatic difference in forward
+progress being made, with unexpected delays, timeouts or even crashes
+posible. Worse, there could be little to no system messages pointing to
+the cause of such behavior. Thus, such a feature would need to be made
+*opt-in* for BRS-I compliance. This could be done implicitly via loading
+of system-specific drivers, or explicitly via firmware setup and
+configuration utilities. The actual meaning of the default (compatible to
+BRS-I) configuration would be highly specific to the vendor. In this example,
+it could capping all harts at the same performance level, or it could mean
+disabling efficiency harts.

--- a/recipes.adoc
+++ b/recipes.adoc
@@ -11,11 +11,35 @@ and BRS-B (for "Bespoke").
 
 === BRS-I Recipe
 
-To simplify software testing and distribution, many operating system
-providers wish to build a single ACPI-based operating system image
-that can be booted and run on platforms supporting a common
-specification base.  The BRS-I recipe documents a standard runtime
-firmware interface to facilitate this.
+The BRS-I recipe aims to simplify end-user experiences, software
+compatibility and OS distribution, by definining a common specification
+for boot and runtime interfaces. BRS-I is expected to be used by
+general-purpose compute devices such as servers, desktops, laptops and
+other devices with industry expectations on silicon vendor, OS and software
+ecosystem interoperatbility. BRS-I enables operating system
+providers to build a single *generic* operating system image that can be
+*successfully booted* on compliant systems. *Generic* means not requiring
+system-specific customizations - only an implementation of BRS-I
+requirements. *Successfully boot* means basic system configuration,
+sufficient for detecting the need for system-specific drivers and
+loading such drivers.
+
+It is understood that systems will deliver features beyond those covered
+by BRS-I. However, software written against a specific version of BRS-I
+must run, unaltered, without *anomalous and unexpected behavior* on
+systems that include such features and that are compliant to that specific
+version of BRS-I. Such behavior, caused by factors entirely unknown to
+a generic OS, is hard to diagnose and always results in a terrible user
+experience that negatively affects the value of the whole RISC-V
+standards-based ecosystem. *Anomalous and unexpected behavior* is taken
+to mean system instability and worst-case behavior for non-specialized
+workloads, but does not include suboptimal/unoptimized behavior or
+missing I/O or accelerator drivers.
+
+A key tenet of BRS-I is constraining behavior outside the scope of BRS-I.
+Features violating the principle of least surprise and causing anomalous and
+unexpected behavior in a generic OS must be configured by firmware as opt-in.
+<<recipe-brs-i-guidance, See additional guidance>>.
 
 .BRS-I Recipe Overview
 [width=90%]


### PR DESCRIPTION
1) A BRS-I compliant system must be able to boot a BRS-I compliant OS. (so long as both target the same BRS-I version).
2) If there are extra features present outside the scope of BRS, these must be exposed/configured out of the box in way that doesn't violate (1).