### PR TITLE
Remove redundant language

### DIFF
--- a/acpi.adoc
+++ b/acpi.adoc
@@ -24,8 +24,7 @@ A compliant system must:
 
 === ACPI-specific Hardware Requirements
 
-This section lists the BRS-specific hardware requirements imposed by
-ACPI support.
+This section lists the requirements imposed by ACPI support.
 
 [[acpi-hw-reduced]]
 ==== HW-Reduced ACPI Model
@@ -35,7 +34,7 @@ This means the hardware portion of cite:[ACPI] (Section 4) is not required or
 supported. All functionality is instead provided through equivalent
 software-defined interfaces and the complexity in supporting ACPI is reduced.
 
-The following additional BRS requirements apply:
+The following additional requirements apply:
 
 * No FACS table.
 * Both interrupt-signaled and GPIO-signaled ACPI Events are supported
@@ -67,11 +66,10 @@ through the driver-backed OperationRegion.
 
 === Additional ACPI Table Requirements
 
-This section lists additional BRS-specific requirements
-for the mandatory and conditionally-required ACPI tables in a compliant
-system.
+This section lists additional requirements for the mandatory and
+conditionally-required ACPI tables in a compliant system.
 
-This section does not list ACPI tables without additional BRS-imposed
+This section does not list ACPI tables without additional
 requirements.
 
 All ACPI tables not listed here may be used, if they comply with the
@@ -97,9 +95,9 @@ It is mandatory, even for systems with a simple hart topology.
 
 ==== Conditionally Required ACPI Tables
 
-This section lists BRS-specific requirements for ACPI tables that depend
-on hardware features that may not be present in compliant systems.
-For example, some systems may not have PCIe busses or a serial port.
+This section lists requirements for ACPI tables that depend on
+features that may not be present in compliant systems.  For example,
+some systems may not have PCIe busses or a serial port.
 
 [[acpi-mcfg]]
 ===== MCFG
@@ -138,8 +136,8 @@ Generic Address Structure).
 [[acpi-aml]]
 === ACPI Methods and Objects
 
-This section lists additional BRS-specific requirements for ACPI
-methods and objects.
+This section lists additional requirements for ACPI methods and
+objects.
 
 <<acpi-guidance-aml, See additional guidance>>.
 


### PR DESCRIPTION
This is the BRS; it is unnecessary to qualify requirements as "BRS-specific" or similar.

As implementations may vary, avoid "hardware requirements"; they are simply "requirements".